### PR TITLE
fix: getDomNode

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+src/
+scripts/
+examples/

--- a/examples/counter/setup.js
+++ b/examples/counter/setup.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const enzyme = require('enzyme');
-const Adapter = require('enzyme-adapter-rax');
+import enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-rax';
+
 
 // Setup Enzyme
 enzyme.configure({ adapter: new Adapter() });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enzyme-adapter-rax",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Enzyme adapter for Rax",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Adapter.js
+++ b/src/Adapter.js
@@ -5,7 +5,7 @@ import isValidElement from 'rax-is-valid-element';
 import { EnzymeAdapter } from 'enzyme';
 import createMountWrapper from './createMountWrapper';
 import RootFinder from './RootFinder';
-import DriverDOM from 'driver-dom';
+import * as DriverDOM from 'driver-dom';
 import { isArrayLike, mapFind, flatten, ensureKeyOrUndefined } from './utils';
 import { CURRENT_ELEMENT, INSTANCE, INTERNAL, RENDERED_COMPONENT, RENDERED_CHILDREN, HOST_NODE } from './constants';
 
@@ -388,7 +388,9 @@ class RaxAdapter extends EnzymeAdapter {
   }
 
   nodeToHostNode(node) {
-    return findDOMNode(node.instance[INTERNAL]);
+    const instance = node.instance;
+    const hostNode = instance[INTERNAL][HOST_NODE];
+    return findDOMNode(hostNode ? hostNode : instance);
   }
 
   isValidElement(element) {


### PR DESCRIPTION
mount 模式中使用 `wrapper.getDomNode` 在获取 native node 节点时需要通过 `node.instance` 作为 `findDomNode` 的入参